### PR TITLE
feat(sdk): introduce module trait, core types, error model, and prelude

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: maxijaxi
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+
+# Added by cargo
+
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 resolver = "2"
 members = [
-    "maia-core",
+    # "maia-core",
     "maia-sdk",
-    "maia-cli",
-    "maia-module/*",
+    # "maia-cli",
+    # "maia-module/*",
 ]
 
 [workspace.package]
@@ -38,7 +38,7 @@ wasmtime-wasi = "36.0.2"
 
 # Discovery
 mdns = "3.0.0"
-libp2p = { version = "0.56.0", optional = true }
+libp2p = "0.56.0"
 
 # Cryptography
 ed25519-dalek = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,101 @@
+[workspace]
+resolver = "2"
+members = [
+    "maia-core",
+    "maia-sdk",
+    "maia-cli",
+    "maia-module/*",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+authors = ["Maximilian Schuster"]
+license = "MIT"
+repository = "https://github.com/maxijaxi/maia"
+# homepage = ""
+rust-version = "1.85.0"
+
+[workspace.dependencies]
+# Async runtime
+tokio = { version = "1.47.1", features = ["full"] }
+async-trait = "0.1.89"
+futures = "0.3.31"
+
+# Serialization
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+bincode = "2.0.1"
+
+# Networking
+tonic = "0.14.2"
+prost = "0.14.1"
+quinn = "0.11.9"
+
+# WASM runtime
+wasmtime = "36.0.2"
+wasmtime-wasi = "36.0.2"
+
+# Discovery
+mdns = "3.0.0"
+libp2p = { version = "0.56.0", optional = true }
+
+# Cryptography
+ed25519-dalek = "2.2.0"
+x25519-dalek = "2.0.1"
+aes-gcm = "0.10.3"
+
+# Utils
+uuid = { version = "1.18.1", features = ["v4", "serde" ] }
+chrono = { version = "0.4.42", features = ["serde"] }
+anyhow = "1.0.99"
+thiserror = "2.0.16"
+
+# Logging
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+
+# Testing
+proptest = "1.7.0"
+criterion = { version = "0.7.0", features = ["html_reports"] }
+
+# CLI
+clap = { version = "4.5.47", features = ["derive", "color"] }
+
+# Internal crates
+maia-core = { path = "maia-core" }
+maia-sdk = { path = "maia-sdk" }
+
+[profile.dev]
+opt-level = 0
+debug = true
+split-debuginfo = "unpacked"
+strip = "none"
+debug-assertions = true
+overflow-checks = true
+lto = false
+panic = "unwind"
+incremental = true
+codegen-units = 256
+rpath = false
+
+[profile.release]
+opt-level = 3
+debug = false
+strip = "symbols"
+debug-assertions = false
+overflow-checks = false
+lto = "thin"
+panic = "abort"
+incremental = false
+codegen-units = 1
+rpath = false
+
+[profile.bench]
+inherits = "release"
+debug = true
+strip = "none"
+
+[workspace.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # MAIA
+
+A project to supercharge todays AI in a private, secure and controlable way, using moduling as a core principle!
+Everything is a module!
+
+**open source and community driven future**
+
+// more details soon

--- a/maia-cli/Cargo.toml
+++ b/maia-cli/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "maia-cli"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "maia"
+path = "src/main.rs"
+
+[dependencies]
+# Core
+maia-core = { workspace = true }
+maia-sdk = { workspace = true }
+
+clap = { workspace = true }
+
+
+tokio = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+anyhow = { workspace = true }
+
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/maia-core/Cargo.toml
+++ b/maia-core/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "maia-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+bincode = { workspace = true }
+
+tonic = { workspace = true }
+prost = { workspace = true }
+
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+
+mdns = { workspace = true }
+
+ed25519-dalek = { workspace = true }
+x25519-dalek = { workspace = true }
+aes-gcm = { workspace = true }
+
+uuid = { workspace = true }
+chrono = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# Internal
+maia-sdk = { path = "../maia-sdk" }
+
+[dev-dependencies]
+proptest = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "routing"
+harness = false
+
+[[bench]]
+name = "message_passing"
+harness = false

--- a/maia-sdk/Cargo.toml
+++ b/maia-sdk/Cargo.toml
@@ -27,4 +27,4 @@ proptest = { workspace = true }
 
 [features]
 default = []
-test-utils = ["tokio/test-uitl"]
+test-utils = ["tokio/test-util"]

--- a/maia-sdk/Cargo.toml
+++ b/maia-sdk/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "maia-sdk"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio = { workspace = true, features = ["sync", "rt"] }
+async-trait = { workspace = true }
+futures = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+uuid = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros"] }
+proptest = { workspace = true }
+
+[features]
+default = []
+test-utils = ["tokio/test-uitl"]

--- a/maia-sdk/src/error.rs
+++ b/maia-sdk/src/error.rs
@@ -3,10 +3,10 @@
 //! Follows the principle: All errors are either recoverable (can retry) or fatal (must handle differently).
 //! Every error provides context and recovery suggestions.
 
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
-use serde::{Deserialize, Serialize};
-use chrono::{DateTime, Utc};
 
 /// Main error type for maia modules
 #[derive(Debug, Clone, Error)]
@@ -30,10 +30,7 @@ pub enum TemporaryError {
     },
 
     #[error("Request timeout after {timeout_ms}ms")]
-    Timeout {
-        timeout_ms: u64,
-        operation: String,
-    },
+    Timeout { timeout_ms: u64, operation: String },
 
     #[error("Rate limit exceeded: {message}")]
     RateLimited {
@@ -42,26 +39,17 @@ pub enum TemporaryError {
     },
 
     #[error("Network error: {message}")]
-    Network {
-        message: String,
-        recoverable: bool,
-    },
+    Network { message: String, recoverable: bool },
 
     #[error("Module temporarily unavailable: {module}")]
-    ModuleUnavailable {
-        module: String,
-        reason: String,
-    },
+    ModuleUnavailable { module: String, reason: String },
 }
 
 /// Fatal errors that cannot be retried with same parameters
 #[derive(Debug, Error, Clone, Serialize, Deserialize)]
 pub enum FatalError {
     #[error("Module not found: {module}")]
-    ModuleNotFound {
-        module: String,
-        suggestion: String,
-    },
+    ModuleNotFound { module: String, suggestion: String },
 
     #[error("Capability not found: {capability}")]
     CapabilityNotFound {
@@ -89,10 +77,7 @@ pub enum FatalError {
     },
 
     #[error("Incompatible version: requires {required}, got {actual}")]
-    VersionMismatch {
-        required: String,
-        actual: String,
-    },
+    VersionMismatch { required: String, actual: String },
 
     #[error("Resource limit exceeded: {resource}")]
     ResourceExhausted {
@@ -258,7 +243,7 @@ impl From<ContextualError> for ErrorInfo {
 }
 
 /// Get error code for serialization
-fn  error_code(error: &(dyn std::error::Error + 'static)) -> &'static str {
+fn error_code(error: &(dyn std::error::Error + 'static)) -> &'static str {
     // Use type name as error code
     // In prod, we'd have a proper error code mapping
     if error.is::<TemporaryError>() {

--- a/maia-sdk/src/error.rs
+++ b/maia-sdk/src/error.rs
@@ -1,0 +1,316 @@
+//! Error types for maia modules and core system.
+//!
+//! Follow the principle: All errors are either recoverable (can retry) or fatal (must handle differently).
+//! Every error provides context and recovery suggestions.
+
+use std::fmt;
+use thiserror::Error;
+use serde::{Deserialize, Serialioze};
+use chrono::{DateTime, Utc};
+
+/// Main error type for maia modules
+#[derive(Debug, Error)]
+pub enum ModuleError {
+    /// Temporary Errors that can be retried
+    #[error("Temporary error: {0}")]
+    Temporary(#[from] TemporaryError),
+
+    /// Fatal error that require different handling
+    Fatal(#[from] FatalError),
+}
+
+/// Temporary errors that may succeed on retry
+#[derive(Debug, Error, Clone, Serialize, Deserialize)]
+pub enum TemporaryError {
+    #[error("Resource temporarily unavailable: {resource}")]
+    ResourceBusy {
+        resource: String,
+        retry_after: Option<DateTime<Utc>>,
+    },
+
+    #[error("Request timeout after {timeout_ms}ms")]
+    Timeout {
+        timeout_ms: u64,
+        operation: string,
+    },
+
+    #[error("Rate limit exceeded: {message}")]
+    RateLimited {
+        message: String,
+        retry_after: Option<DateTime<Utc>>,
+    },
+
+    #[error("Network error: {message}")]
+    Network {
+        message: String,
+        recoverable: bool,
+    },
+
+    #[error("Module temporarily unavailable: {module}")]
+    ModuleUnavailable {
+        module: String,
+        reason: String,
+    },
+}
+
+/// Fatal errors that cannot be retried with same parameters
+#[derive(Debug, Error, Clone, Serialize, Deserialize)]
+pub enum FatalError {
+    #[error("Module not found: {module}")]
+    ModuleNotFound {
+        module: String,
+        suggestion: String,
+    },
+
+    #[error("Capability not found: {capability}")]
+    CapabilityNotFound {
+        capability: String,
+        available: Vec<String>,
+    },
+
+    #[error("Unauthorized access to {resource}")]
+    Unauthorized {
+        resource: String,
+        required_permissions: Vec<String>,
+    },
+
+    #[error("Invalid request: {message}")]
+    InvalidRequest {
+        message: String,
+        field: Option<String>,
+    },
+
+    #[error("Module initialization failed: {module}")]
+    InitializationFailed {
+        module: String,
+        reason: String,
+        suggestion: String,
+    },
+
+    #[error("Incompatible version: requires {required}, got {actual}")]
+    VersionMismatch {
+        required: String,
+        actual: String,
+    },
+
+    #[error("Resource limit exceeded: {resource")]
+    ResourceExhausted {
+        resource: String,
+        limit: String,
+        current: String,
+    },
+
+    #[error("Operation not implemented")]
+    NotImplemented,
+
+    #[error("Internal error: {message}")]
+    Internal {
+        message: String,
+        details: Option<String>,
+    },
+}
+
+/// Context information for errors
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorContext {
+    /// When the error occurred
+    pub timestamp: DateTime<Utc>,
+
+    /// Which module generated the error
+    pub module_id: Option<String>,
+
+    /// Which capability was being accessed
+    pub capability: Option<String>,
+
+    /// Request ID for tracing
+    pub request_id: Option<uuid::Uuid>,
+
+    /// Suggested recovery action
+    pub suggestion: Option<String>,
+
+    /// Additional metadata
+    pub metadata: serde_json::Value,
+}
+
+impl ErrorContext {
+    /// Create a new error context with current timestamp
+    pub fn new() -> Self {
+        Self {
+            timestamp: Utc::now(),
+            module_id: None,
+            capability: None,
+            request_id: None,
+            suggestion: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    /// Set module ID
+    pub fn with_module(mut self, module_id: impl Into<String>) -> Self {
+        self.module_id = Some(module_id.into());
+        self
+    }
+
+    /// Set capability
+    pub fn with_capability(mut self, capability: impl Into<String>) -> Self {
+        self.capability = Some(capability.into());
+        self
+    }
+
+    /// Set request ID
+    pub fn with_request_id(mut self, request_id: uuid::Uuid) -> Self {
+        self.request_id = Some(request_id);
+        self
+    }
+
+    /// Set recovery suggestion
+    pub fn with_suggestion(mut self, suggestion: impl Into<String>) -> Self {
+        self.suggestion = Some(suggestion.into());
+        self
+    }
+}
+
+impl Default for ErrorContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error with full context
+#[derive(Debug, Clone)]
+pub struct ContextualError {
+    pub error: ModuleError,
+    pub context: ErrorContext,
+}
+
+impl fmt::Display for ContextualError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.error)?;
+        if let Some(ref module) = self.context.module_id {
+            write!(f, " [module: {}]", module)?;
+        }
+        if let Some(ref cap) = self.context.capability {
+            write!(f, " [capability: {}]", cap)?;
+        }
+        if let Some(ref suggestion) = self.context.suggestion {
+            write!(f, " [suggestion: {}]", suggestion)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ContextualError {}
+
+/// Helper trait for adding context to errors
+pub trait ErrorExt {
+    /// Add context to this error
+    fn context(self, context: ErrorContext) -> ContextualError;
+
+    /// Add context with just a suggestion
+    fn with_suggestion(self, suggestion: impl Into<String>) -> ContextualError;
+}
+
+impl ErrorExt for ModuleError {
+    fn context(self, context: ErrorContext) -> ContextualError {
+        ContextualError {
+            error: self,
+            context,
+        }
+    }
+
+    fn with_suggestion(self, suggestion: impl Into<String>) -> ContextualError {
+        self.context(ErrorContext::new().with_suggestion(suggestion))
+    }
+}
+
+/// Serializable error info for network transmission
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorInfo {
+    pub code: String,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+    pub recoverable: bool,
+    pub context: Option<ErrorContext>,
+}
+
+impl From<ModuleError> for ErrorInfo {
+    fn from(error: ModuleError) -> Self {
+        let (code, recoverable) = match &error {
+            ModuleError::Temporary(e) => (format!("TEMP_{}", error_code(e)), true),
+            ModuleError::Fatal(e) => (format!("FATAL_{}", error_code(e)), false),
+        };
+
+        ErrorInfo {
+            code,
+            message: error.to_string(),
+            details: None,
+            recoverable,
+            context: None,
+        }
+    }
+}
+
+impl From<ContextualError> for ErrorInfo {
+    fn from(error: ContextualError) -> Self {
+        let mut info = Error::from(error.error);
+        into.context = Some(error.context);
+        info
+    }
+}
+
+/// Get error code for serialization
+fn  error_code(error: &dyn std::error::Error) -> &'static str {
+    /// Use type name as error code
+    /// In prod, we'd have a proper error code mapping
+    if error.is::<TemporaryError>() {
+        "TEMPORARY"
+    } else {
+        "FATAL"
+    }
+}
+
+/// Result type alias for module operations
+pub type Result<T> = std::result::Result<T, ModuleError>;
+
+/// Result type with context
+pub type ContextResult<T> = std::result::Result<T, ContextualError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_context_builder() {
+        let context = ErrorContext::new()
+            .with_module("test-module")
+            .with_capability("test.capability")
+            .with_suggestion("Try again later");
+
+        assert_eq!(context.module_id, Some("test-module".to_string()));
+        assert_eq!(context.capability, Some("test.capability".to_string()));
+        assert_eq!(context.suggestion, Some("Try again later".to_string()));
+    }
+
+    #[test]
+    fn test_error_serialization() {
+        let error = ModuleError::Fatal(FatalError::ModuleNotFound {
+            module: "missing".to_string(),
+            suggestion: "Install the module first".to_string(),
+        });
+
+        let info = ErrorInfo::from(error);
+        assert!(!info.recoverable);
+        assert!(info.code.starts_with("FATAL_"));
+    }
+
+    #[test]
+    fn test_contextual_error() {
+        let error = ModuleError::Temporary(TemporaryError:: Timeout {
+            timeout_ms: 5000,
+            operation: "module_load".to_string(),
+        });
+
+        let contextual = error.with_suggestion("Increase timeout or check network");
+        assert!(contextual.context.suggestion.is_some());
+    }
+}

--- a/maia-sdk/src/error.rs
+++ b/maia-sdk/src/error.rs
@@ -1,21 +1,22 @@
-//! Error types for maia modules and core system.
+//! Error types for MAIA modules and core system.
 //!
-//! Follow the principle: All errors are either recoverable (can retry) or fatal (must handle differently).
+//! Follows the principle: All errors are either recoverable (can retry) or fatal (must handle differently).
 //! Every error provides context and recovery suggestions.
 
 use std::fmt;
 use thiserror::Error;
-use serde::{Deserialize, Serialioze};
+use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 
 /// Main error type for maia modules
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum ModuleError {
-    /// Temporary Errors that can be retried
+    /// Temporary errors that can be retried
     #[error("Temporary error: {0}")]
     Temporary(#[from] TemporaryError),
 
-    /// Fatal error that require different handling
+    /// Fatal errors that require different handling
+    #[error("Fatal error: {0}")]
     Fatal(#[from] FatalError),
 }
 
@@ -31,7 +32,7 @@ pub enum TemporaryError {
     #[error("Request timeout after {timeout_ms}ms")]
     Timeout {
         timeout_ms: u64,
-        operation: string,
+        operation: String,
     },
 
     #[error("Rate limit exceeded: {message}")]
@@ -93,7 +94,7 @@ pub enum FatalError {
         actual: String,
     },
 
-    #[error("Resource limit exceeded: {resource")]
+    #[error("Resource limit exceeded: {resource}")]
     ResourceExhausted {
         resource: String,
         limit: String,
@@ -177,7 +178,7 @@ impl Default for ErrorContext {
 }
 
 /// Error with full context
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub struct ContextualError {
     pub error: ModuleError,
     pub context: ErrorContext,
@@ -198,8 +199,6 @@ impl fmt::Display for ContextualError {
         Ok(())
     }
 }
-
-impl std::error::Error for ContextualError {}
 
 /// Helper trait for adding context to errors
 pub trait ErrorExt {
@@ -252,16 +251,16 @@ impl From<ModuleError> for ErrorInfo {
 
 impl From<ContextualError> for ErrorInfo {
     fn from(error: ContextualError) -> Self {
-        let mut info = Error::from(error.error);
-        into.context = Some(error.context);
+        let mut info = ErrorInfo::from(error.error);
+        info.context = Some(error.context);
         info
     }
 }
 
 /// Get error code for serialization
-fn  error_code(error: &dyn std::error::Error) -> &'static str {
-    /// Use type name as error code
-    /// In prod, we'd have a proper error code mapping
+fn  error_code(error: &(dyn std::error::Error + 'static)) -> &'static str {
+    // Use type name as error code
+    // In prod, we'd have a proper error code mapping
     if error.is::<TemporaryError>() {
         "TEMPORARY"
     } else {
@@ -305,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_contextual_error() {
-        let error = ModuleError::Temporary(TemporaryError:: Timeout {
+        let error = ModuleError::Temporary(TemporaryError::Timeout {
             timeout_ms: 5000,
             operation: "module_load".to_string(),
         });

--- a/maia-sdk/src/lib.rs
+++ b/maia-sdk/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod types;

--- a/maia-sdk/src/lib.rs
+++ b/maia-sdk/src/lib.rs
@@ -1,2 +1,111 @@
+//! MAIA SDK - Software Development Kit for building MAIA modules.
+//!
+//! This crate provides the core traits, types and utilities needed
+//! to develop modules for the MAIA distributed AI infrastructure.
+//!
+//! # Quick Start
+//!
+//! ```ignore
+//! use maia_sdk::prelude::*;
+//! use async_trait::async_trait;
+//!
+//! struct MyModule;
+//!
+//! #[async_trait]
+//! impl MaiaModule for MyModule {
+//!     fn manifest(&self) -> ModuleManifest {
+//!         ModuleManifest::minimal("my.module", "My Module")
+//!     }
+//!
+//!     fn capabilities(&self) -> Vec<Capability> {
+//!         vec![Capability::new("my.capability")]
+//!     }
+//!
+//!     // ... implement other required methods
+//! }
+//!
+//! // Export for dynamic loading
+//! maia_module!(MyModule);
+//! ```
+
+#![doc(html_root_url = "https://docs.maia-protocol.org/sdk")]
+#![warn(missing_docs)]
+#![warn(rustdoc::missing_crate_level_docs)]
+
+/// Error types and handling utilities
 pub mod error;
+
+/// Core types for message passing and communication
 pub mod types;
+
+/// Module trait and related definitions
+pub mod traits;
+
+/// Re-export async_trait for convenience
+pub use async_trait::async_trait;
+
+/// Prelude module for convenient imports
+///
+/// Import everything you need with:
+/// ```ignore
+/// use maia_sdk::prelude::*;
+/// ```
+pub mod prelude {
+    pub use crate::error::{
+        ContextResult, ErrorContext, ErrorExt, FatalError, ModuleError, Result, TemporaryError,
+    };
+
+    pub use crate::types::{
+        Capability, ModuleId, NetworkId, NodeId, Request, RequestMetadata, Response,
+        ResponseMetadata, StreamConfig, StreamDirection, StreamHandle, Version,
+    };
+
+    pub use crate::traits::{
+        HealthStatus, IsolationLevel, LogLevel, MaiaModule, ModuleCallback, ModuleContext,
+        ModuleManifest, Permission, Requirement, ResourceLimits, ResourceRequirements,
+    };
+
+    pub use crate::maia_module;
+    pub use async_trait::async_trait;
+}
+
+/// Version information for the SDK
+pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Get SDK version as a Version struct
+pub fn parse_version(version_str: &str) -> types::Version {
+    // Parse from Cargo.toml version
+    let parts: Vec<&str> = version_str.split('.').collect();
+    types::Version::new(
+        parts.get(0).and_then(|s| s.parse().ok()).unwrap_or(0),
+        parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0),
+        parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0),
+    )
+}
+
+pub fn sdk_version() -> types::Version {
+    parse_version(env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sdk_version() {
+        let version = parse_version("1.2.3");
+        assert_eq!(version.major, 1);
+        assert_eq!(version.minor, 2);
+        assert_eq!(version.patch, 3);
+    }
+
+    #[test]
+    fn test_prelude_imports() {
+        // Just verify that prelude items are accessible
+        use crate::prelude::*;
+
+        let _cap = Capability::new("test");
+        let _version = Version::new(1, 0, 0);
+        let _manifest = ModuleManifest::minimal("test", "Test");
+    }
+}

--- a/maia-sdk/src/traits.rs
+++ b/maia-sdk/src/traits.rs
@@ -1,0 +1,505 @@
+//! Core trait definitions for MAIA modules.
+//!
+//! This is the fundamental abstraction that all modules must implement.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::error::{ModuleError, Result};
+use crate::types::{Capability, ModuleId, NodeId, Request, Response, StreamHandle, Version};
+
+/// The core trait that all MAIA modules must implement.
+///
+/// This trait defines the contract between modules and the MAIA runtime.
+/// Everything in MAIA is a module except the minimal core routing.
+#[async_trait]
+pub trait MaiaModule: Send + Sync {
+    /// Get the module's manifest containing metadata and requirements.
+    fn manifest(&self) -> ModuleManifest;
+
+    /// List capabilities this module provides.
+    ///
+    /// These are the functions this module can perform.
+    /// Example: `["ai.nlp.generate", "ai.nlp.summarize"]`
+    fn capabilities(&self) -> Vec<Capability>;
+
+    /// List requirements this module needs from other modules
+    ///
+    /// These are capabilities this module depends on.
+    /// Example: `["storage.kv", "network.http"]`
+    fn requirements(&self) -> Vec<Requirement>;
+
+    /// Initialize the module with its runtime context
+    ///
+    /// Called once when the module is loaded
+    async fn initialize(&mut self, context: ModuleContext) -> Result<()>;
+
+    /// Start the module.
+    ///
+    /// Called after initialization to begin operation.
+    async fn start(&mut self) -> Result<()>;
+
+    /// Stop the module gracefully.
+    ///
+    /// Should clean up resources and save state if needed.
+    async fn stop(&mut self) -> Result<()>;
+
+    /// Handle a request for one of this module's capabilities.
+    ///
+    /// This is the main entry point for module functionality.
+    async fn handle_request(&mut self, request: Request) -> Result<Response>;
+
+    /// Handle a streaming operation (optional).
+    ///
+    /// Not all modules need to support streaming.
+    async fn handle_stream(&mut self, stream: StreamHandle) -> Result<()> {
+        Err(ModuleError::Fatal(crate::error::FatalError::NotImplemented))
+    }
+
+    /// Get current module health status (optional).
+    ///
+    /// Used for monitoring and load balancing.
+    async fn health_check(&self) -> HealthStatus {
+        HealthStatus::Healthy
+    }
+
+    /// Get module metrics (optional).
+    ///
+    /// Used for observability and debugging.
+    async fn get_metrics(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+}
+
+/// Module manifest containing metadata and configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleManifest {
+    /// Unique identifier (e.g. "com.example.weather")
+    pub id: String,
+
+    /// Human-readable name
+    pub name: String,
+
+    /// Semantic version
+    pub version: Version,
+
+    /// Author email or identifier
+    pub author: String,
+
+    /// License (e.g. "MIT", "Apache-2.0")
+    pub license: String,
+
+    /// Brief description
+    pub description: Option<String>,
+
+    /// Homepage or repository URL
+    pub homepage: Option<String>,
+
+    /// Cryptographic signature for verification
+    pub signature: Option<Vec<u8>>,
+
+    /// Required isolation level
+    pub isolation: IsolationLevel,
+
+    /// Resource requirements
+    pub resources: ResourceRequirements,
+
+    /// Security permissions needed
+    pub permissions: Vec<Permission>,
+}
+
+impl ModuleManifest {
+    /// Create a minimal manifest for testing
+    pub fn minimal(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            version: Version::new(0, 1, 0),
+            author: "unknown".to_string(),
+            license: "MIT".to_string(),
+            description: None,
+            homepage: None,
+            signature: None,
+            isolation: IsolationLevel::Wasm,
+            resources: ResourceRequirements::default(),
+            permissions: vec![],
+        }
+    }
+}
+
+/// Module isolation level for security.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IsolationLevel {
+    /// Full sandboxing via WebAssembly
+    Wasm,
+    /// Separate OS process
+    Process,
+    /// TODO: (future) Container isolation
+    Container,
+    /// Same process (only for trusted core modules)
+    Native,
+}
+
+impl Default for IsolationLevel {
+    fn default() -> Self {
+        Self::Wasm
+    }
+}
+
+/// Resource requirements for a module
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceRequirements {
+    /// Memory limit in MB
+    pub memory_mb: u32,
+
+    /// CPU shares (relative weight)
+    pub cpu_shares: u32,
+
+    /// Disk space in MB (optional)
+    pub disk_mb: Option<u32>,
+
+    /// Network bandwidth in Mbps (optional)
+    pub network_mbps: Option<u32>,
+
+    /// GPU requirements (optional)
+    pub gpu: Option<GpuRequirement>,
+}
+
+impl Default for ResourceRequirements {
+    fn default() -> Self {
+        Self {
+            memory_mb: 128,
+            cpu_shares: 100,
+            disk_mb: None,
+            network_mbps: None,
+            gpu: None,
+        }
+    }
+}
+
+/// GPU requirements for modules that need acceleration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GpuRequirement {
+    /// Minimum VRAM in MB
+    pub vram_mb: u32,
+
+    /// Required compute capability (e.g. "7.5" for CUDA)
+    pub compute_capability: Option<String>,
+
+    /// Preferred vendor (e.g. "nvidia", "amd")
+    pub vendor: Option<String>,
+}
+
+/// Security permissions that module can request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Permission {
+    /// Network access to specific domains
+    Network(String),
+
+    /// File system access to paths
+    FileSystem(String),
+
+    /// Environment variable access
+    Environment(String),
+
+    /// System call access (Linux)
+    Syscall(String),
+
+    /// Access to hardware devices
+    Device(String),
+
+    /// Custom permission
+    Custom(String),
+}
+
+/// Requirement for a capability from another module
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Requirement {
+    /// The capability needed
+    pub capability: Capability,
+
+    /// Minimum version required
+    pub min_version: Option<Version>,
+
+    /// Whether this is optional
+    pub optional: bool,
+
+    /// Preferred provider (if any)
+    pub preferred_provider: Option<String>,
+}
+
+impl Requirement {
+    /// Create a required capability requirement
+    pub fn required(capability: impl Into<Capability>) -> Self {
+        Self {
+            capability: capability.into(),
+            min_version: None,
+            optional: false,
+            preferred_provider: None,
+        }
+    }
+
+    /// Create an optional capability requirement
+    pub fn optional(capability: impl Into<Capability>) -> Self {
+        Self {
+            capability: capability.into(),
+            min_version: None,
+            optional: true,
+            preferred_provider: None,
+        }
+    }
+}
+
+/// Runtime context provided to modules during initialization
+#[derive(Debug, Clone)]
+pub struct ModuleContext {
+    /// The module's assigned ID
+    pub module_id: ModuleId,
+
+    /// Available capabilities in the system
+    pub available_capabilities: Vec<Capability>,
+
+    /// Resource limits assigned to this module
+    pub resource_limits: ResourceLimits,
+
+    /// Configuration parameters
+    pub config: HashMap<String, serde_json::Value>,
+
+    /// Callback channel for module to core communication
+    pub callback: ModuleCallback,
+}
+
+/// Resource limits enforced at runtime
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceLimits {
+    /// Maximum memory in bytes
+    pub max_memory: usize,
+
+    /// CPU time quota in milliseconds per second
+    pub cpu_quota_ms: u32,
+
+    /// Maximum open file descriptors
+    pub max_fds: u32,
+
+    /// Maximum threads/tasks
+    pub max_threads: u32,
+}
+
+impl Default for ResourceLimits {
+    fn default() -> Self {
+        Self {
+            max_memory: 128 * 1024 * 1024, // 128 MB
+            cpu_quota_ms: 900,             // 90% of one core
+            max_fds: 256,
+            max_threads: 10,
+        }
+    }
+}
+
+/// Callback channel for modules to communicate with the core.
+#[derive(Debug, Clone)]
+pub struct ModuleCallback {
+    sender: tokio::sync::mpsc::Sender<CallbackMessage>,
+}
+
+impl ModuleCallback {
+    /// Create a new callback channel
+    pub fn new(sender: tokio::sync::mpsc::Sender<CallbackMessage>) -> Self {
+        Self { sender }
+    }
+
+    /// Log a message
+    pub async fn log(&self, level: LogLevel, message: String) -> Result<()> {
+        self.sender
+            .send(CallbackMessage::Log { level, message })
+            .await
+            .map_err(|_| {
+                ModuleError::Fatal(crate::error::FatalError::Internal {
+                    message: "Failed to send log message".to_string(),
+                    details: None,
+                })
+            })?;
+        Ok(())
+    }
+
+    /// Request a capability from another module
+    pub async fn request_capability(&self, request: Request) -> Result<Response> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .send(CallbackMessage::Request {
+                request,
+                response: tx,
+            })
+            .await
+            .map_err(|_| {
+                ModuleError::Fatal(crate::error::FatalError::Internal {
+                    message: "Failed to send capability request".to_string(),
+                    details: None,
+                })
+            })?;
+
+        rx.await.map_err(|_| {
+            ModuleError::Fatal(crate::error::FatalError::Internal {
+                message: "Failed to receive capability response".to_string(),
+                details: None,
+            })
+        })?
+    }
+
+    /// Report a metric
+    pub async fn report_metric(&self, name: String, value: serde_json::Value) -> Result<()> {
+        self.sender
+            .send(CallbackMessage::Metric { name, value })
+            .await
+            .map_err(|_| {
+                ModuleError::Fatal(crate::error::FatalError::Internal {
+                    message: "Failed to send metric".to_string(),
+                    details: None,
+                })
+            })?;
+        Ok(())
+    }
+}
+
+/// Messages modules can send back to the core.
+#[derive(Debug)]
+pub enum CallbackMessage {
+    /// Log a message
+    Log { level: LogLevel, message: String },
+    /// Request a capability
+    Request {
+        request: Request,
+        response: tokio::sync::oneshot::Sender<Result<Response>>,
+    },
+    /// Report a metric
+    Metric {
+        name: String,
+        value: serde_json::Value,
+    },
+}
+
+/// Log levels for module logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// Health status of a module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+/// Helper macro for module implementation boilerplate.
+///
+/// Usage:
+/// ```ignore
+/// struct MyModule;
+/// maia_module!(MyModule);
+/// ```
+#[macro_export]
+macro_rules! maia_module {
+    ($module_type:ty) => {
+        /// Entry point for dynamic loading
+        #[no_mangle]
+        pub extern "C" fn create_module() -> Box<dyn $crate::traits::MaiaModule> {
+            Box::new(<$module_type>::default())
+        }
+
+        /// Module type information
+        #[no_mangle]
+        pub extern "C" fn module_type() -> &'static str {
+            stringify!($module_type)
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Example module for testing
+    struct TestModule {
+        initialized: bool,
+    }
+
+    #[async_trait]
+    impl MaiaModule for TestModule {
+        fn manifest(&self) -> ModuleManifest {
+            ModuleManifest::minimal("test.module", "Test Module")
+        }
+
+        fn capabilities(&self) -> Vec<Capability> {
+            vec![Capability::new("test.echo")]
+        }
+
+        fn requirements(&self) -> Vec<Requirement> {
+            vec![]
+        }
+
+        async fn initialize(&mut self, _context: ModuleContext) -> Result<()> {
+            self.initialized = true;
+            Ok(())
+        }
+
+        async fn start(&mut self) -> Result<()> {
+            if !self.initialized {
+                return Err(ModuleError::Fatal(
+                    crate::error::FatalError::InitializationFailed {
+                        module: "test".to_string(),
+                        reason: "Not initialized".to_string(),
+                        suggestion: "Call initialize first".to_string(),
+                    },
+                ));
+            }
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn handle_request(&mut self, request: Request) -> Result<Response> {
+            Ok(Response::success(
+                request.id,
+                json!({
+                    "echo": request.payload
+                }),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_module_lifecycle() {
+        let mut module = TestModule { initialized: false };
+
+        // Should fail to start without initialization
+        assert!(module.start().await.is_err());
+
+        // Create a dummy context
+        let (tx, _rx) = tokio::sync::mpsc::channel(100);
+        let context = ModuleContext {
+            module_id: ModuleId::new(
+                NodeId::new(crate::types::NetworkId::new("test"), "node"),
+                "test-module",
+            ),
+            available_capabilities: vec![],
+            resource_limits: ResourceLimits::default(),
+            config: HashMap::new(),
+            callback: ModuleCallback::new(tx),
+        };
+
+        // Initialize and start should succeed
+        assert!(module.initialize(context).await.is_ok());
+        assert!(module.start().await.is_ok());
+        assert!(module.stop().await.is_ok());
+    }
+}

--- a/maia-sdk/src/types.rs
+++ b/maia-sdk/src/types.rs
@@ -1,10 +1,10 @@
 //! Core types for MAIA message passing and module communication.
 
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
-use uuid::Uuid;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
+use uuid::Uuid;
 
 use crate::error::ErrorInfo;
 
@@ -106,7 +106,9 @@ impl Version {
     /// Check if this version is compatible with a requirement
     pub fn is_compatible(&self, required: &Self) -> bool {
         // Same major version and at least the required minor/patch
-        self.major == required.major && (self.minor > required.minor || (self.minor == required.minor && self.patch >= required.patch))
+        self.major == required.major
+            && (self.minor > required.minor
+                || (self.minor == required.minor && self.patch >= required.patch))
     }
 }
 

--- a/maia-sdk/src/types.rs
+++ b/maia-sdk/src/types.rs
@@ -167,7 +167,7 @@ pub struct Request {
     /// Unique request ID
     pub id: Uuid,
 
-    /// The capability being released
+    /// The capability being requested
     pub capability: Capability,
 
     /// Request payload (JSON)

--- a/maia-sdk/src/types.rs
+++ b/maia-sdk/src/types.rs
@@ -1,4 +1,4 @@
-//! Core types for maia message passing and module communication.
+//! Core types for MAIA message passing and module communication.
 
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
@@ -25,7 +25,7 @@ impl Capability {
 
     /// Parse capability into namespace, category and action
     pub fn parse(&self) -> Option<(String, String, String)> {
-        let parts: Vec<&str> = self.0.split(':').collect();
+        let parts: Vec<&str> = self.0.split('.').collect();
         if parts.len() >= 3 {
             Some((
                 parts[0].to_string(),
@@ -44,14 +44,14 @@ impl Capability {
 
     /// Check if capability matches a pattern (supports wildcards)
     pub fn matches(&self, pattern: &str) -> bool {
-        if pattern = "*" {
+        if pattern == "*" {
             return true;
         }
 
         let pattern_parts: Vec<&str> = pattern.split('.').collect();
         let capability_parts: Vec<&str> = self.0.split('.').collect();
 
-        if pattern_parts.len() >= capability_parts.len() {
+        if pattern_parts.len() > capability_parts.len() {
             return false;
         }
 
@@ -62,7 +62,7 @@ impl Capability {
         }
 
         // If pattern ends with *, match all sub-capabilities
-        pattern_parts.last == Some(&"*") || pattern_parts.len() == capability_parts.len()
+        pattern_parts.last() == Some(&"*") || pattern_parts.len() == capability_parts.len()
     }
 }
 
@@ -106,7 +106,7 @@ impl Version {
     /// Check if this version is compatible with a requirement
     pub fn is_compatible(&self, required: &Self) -> bool {
         // Same major version and at least the required minor/patch
-        self.major == required.majoor && (self.minor > required.minor || (self.minor == required.minor && self.patch >= required.patch))
+        self.major == required.major && (self.minor > required.minor || (self.minor == required.minor && self.patch >= required.patch))
     }
 }
 
@@ -287,7 +287,7 @@ pub struct StreamHandle {
     pub stream_type: Capability,
 
     /// Direction of the stream
-    pub direction: SteamDirection,
+    pub direction: StreamDirection,
 
     /// Stream configuration
     pub config: StreamConfig,
@@ -328,7 +328,7 @@ impl Default for StreamConfig {
 }
 
 /// Network identity (DID)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NetworkId(String);
 
 impl NetworkId {
@@ -349,7 +349,7 @@ impl NetworkId {
 
     /// Get the network name from DID
     pub fn name(&self) -> &str {
-        self.0.strip_prefix("did:maia:").unwrap(&self.0)
+        self.0.strip_prefix("did:maia:").unwrap_or(&self.0)
     }
 }
 
@@ -421,9 +421,9 @@ mod tests {
         let cap = Capability::new("ai.nlp.generate");
 
         assert!(cap.matches("*"));
-        assert!(cap.matches("a1.*"));
-        assert!(cap.matches("a1.nlp.*"));
-        assert!(cap.matches("a1.nlp.generate"));
+        assert!(cap.matches("ai.*"));
+        assert!(cap.matches("ai.nlp.*"));
+        assert!(cap.matches("ai.nlp.generate"));
         assert!(!cap.matches("ai.vision.*"));
         assert!(!cap.matches("storage.*"));
     }
@@ -444,10 +444,10 @@ mod tests {
     #[test]
     fn test_network_id() {
         let id = NetworkId::new("test-home");
-        assert_eq!(id.to_string(), "did.maia:test-home");
+        assert_eq!(id.to_string(), "did:maia:test-home");
         assert_eq!(id.name(), "test-home");
 
-        let parsed = NetworkId::parse("did.maia:test-home").unwrap();
+        let parsed = NetworkId::parse("did:maia:test-network").unwrap();
         assert_eq!(parsed.name(), "test-network");
     }
 }

--- a/maia-sdk/src/types.rs
+++ b/maia-sdk/src/types.rs
@@ -1,0 +1,453 @@
+//! Core types for maia message passing and module communication.
+
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::error::ErrorInfo;
+
+/// A capability identifier following the namespace.category.action pattern
+///
+/// Examples:
+/// - `ai.nlp.generate`
+/// - `storage.kv.get`
+/// - `sensor.temperature.read`
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Capability(String);
+
+impl Capability {
+    /// Create a new capability identifier
+    pub fn new(capability: impl Into<String>) -> Self {
+        Self(capability.into())
+    }
+
+    /// Parse capability into namespace, category and action
+    pub fn parse(&self) -> Option<(String, String, String)> {
+        let parts: Vec<&str> = self.0.split(':').collect();
+        if parts.len() >= 3 {
+            Some((
+                parts[0].to_string(),
+                parts[1].to_string(),
+                parts[2..].join("."),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Get the namespace (first part)
+    pub fn namespace(&self) -> Option<&str> {
+        self.0.split('.').next()
+    }
+
+    /// Check if capability matches a pattern (supports wildcards)
+    pub fn matches(&self, pattern: &str) -> bool {
+        if pattern = "*" {
+            return true;
+        }
+
+        let pattern_parts: Vec<&str> = pattern.split('.').collect();
+        let capability_parts: Vec<&str> = self.0.split('.').collect();
+
+        if pattern_parts.len() >= capability_parts.len() {
+            return false;
+        }
+
+        for (pattern_part, capability_part) in pattern_parts.iter().zip(capability_parts.iter()) {
+            if *pattern_part != "*" && pattern_part != capability_part {
+                return false;
+            }
+        }
+
+        // If pattern ends with *, match all sub-capabilities
+        pattern_parts.last == Some(&"*") || pattern_parts.len() == capability_parts.len()
+    }
+}
+
+impl std::fmt::Display for Capability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for Capability {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for Capability {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Semantic version for modules and capabilities
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    pub pre_release: Option<String>,
+}
+
+impl Version {
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            pre_release: None,
+        }
+    }
+
+    /// Check if this version is compatible with a requirement
+    pub fn is_compatible(&self, required: &Self) -> bool {
+        // Same major version and at least the required minor/patch
+        self.major == required.majoor && (self.minor > required.minor || (self.minor == required.minor && self.patch >= required.patch))
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        if let Some(ref pre) = self.pre_release {
+            write!(f, "-{}", pre)?;
+        }
+        Ok(())
+    }
+}
+
+/// Metadata for requests
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestMetadata {
+    /// Timeout for this request
+    pub timeout: Option<Duration>,
+
+    /// Priority (higher = more important)
+    pub priority: i32,
+
+    /// Originating network/node/module
+    pub origin: Option<String>,
+
+    /// Target network/node/module (for routing)
+    pub target: Option<String>,
+
+    /// Timestamp when request was created
+    pub timestamp: DateTime<Utc>,
+
+    /// Optional tracing context
+    pub trace_id: Option<String>,
+
+    /// Custom metadata
+    pub custom: HashMap<String, serde_json::Value>,
+}
+
+impl Default for RequestMetadata {
+    fn default() -> Self {
+        Self {
+            timeout: Some(Duration::from_secs(20)),
+            priority: 0,
+            origin: None,
+            target: None,
+            timestamp: Utc::now(),
+            trace_id: None,
+            custom: HashMap::new(),
+        }
+    }
+}
+
+/// A request from one module to another
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    /// Unique request ID
+    pub id: Uuid,
+
+    /// The capability being released
+    pub capability: Capability,
+
+    /// Request payload (JSON)
+    pub payload: serde_json::Value,
+
+    /// Request metadata
+    pub metadata: RequestMetadata,
+}
+
+impl Request {
+    /// Create a new request
+    pub fn new(capability: impl Into<Capability>, payload: serde_json::Value) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            capability: capability.into(),
+            payload,
+            metadata: RequestMetadata::default(),
+        }
+    }
+
+    /// Set timeout for this request
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.metadata.timeout = Some(timeout);
+        self
+    }
+
+    /// Set priority for this request
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.metadata.priority = priority;
+        self
+    }
+
+    /// Set target for routing
+    pub fn with_target(mut self, target: impl Into<String>) -> Self {
+        self.metadata.target = Some(target.into());
+        self
+    }
+}
+
+/// Metadata for responses
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseMetadata {
+    /// When the response was created
+    pub timestamp: DateTime<Utc>,
+
+    /// Processing duration in ms
+    pub duration_ms: Option<u64>,
+
+    /// Module that generated the response
+    pub responder: Option<String>,
+
+    /// Custom metadata
+    pub custom: HashMap<String, serde_json::Value>,
+}
+
+impl Default for ResponseMetadata {
+    fn default() -> Self {
+        Self {
+            timestamp: Utc::now(),
+            duration_ms: None,
+            responder: None,
+            custom: HashMap::new(),
+        }
+    }
+}
+
+/// A response to a request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Response {
+    /// ID of the request this responds to
+    pub request_id: Uuid,
+
+    /// Result of the operation
+    pub result: Result<serde_json::Value, ErrorInfo>,
+
+    /// Response metadata
+    pub metadata: ResponseMetadata,
+}
+
+impl Response {
+    /// Create a successful response
+    pub fn success(request_id: Uuid, data: serde_json::Value) -> Self {
+        Self {
+            request_id,
+            result: Ok(data),
+            metadata: ResponseMetadata::default(),
+        }
+    }
+
+    /// Create an error response
+    pub fn error(request_id: Uuid, error: ErrorInfo) -> Self {
+        Self {
+            request_id,
+            result: Err(error),
+            metadata: ResponseMetadata::default(),
+        }
+    }
+
+    /// Set the responder module
+    pub fn with_responder(mut self, responder: impl Into<String>) -> Self {
+        self.metadata.responder = Some(responder.into());
+        self
+    }
+
+    /// Set processing duration
+    pub fn with_duration(mut self, duration: Duration) -> Self {
+        self.metadata.duration_ms = Some(duration.as_millis() as u64);
+        self
+    }
+}
+
+/// Handle for streaming operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamHandle {
+    /// Unique stream ID
+    pub id: Uuid,
+
+    /// Stream type/capability
+    pub stream_type: Capability,
+
+    /// Direction of the stream
+    pub direction: SteamDirection,
+
+    /// Stream configuration
+    pub config: StreamConfig,
+}
+
+/// Direction of a stream
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StreamDirection {
+    /// Module sends data
+    Output,
+    /// Module receives data
+    Input,
+    /// Bidirectional stream
+    Bidirectional,
+}
+
+/// Configuration for streams
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamConfig {
+    /// Maximum buffer size
+    pub buffer_size: usize,
+
+    /// Whether to apply backpressure
+    pub backpressure: bool,
+
+    /// Timeout for stream operations
+    pub timeout: Option<Duration>,
+}
+
+impl Default for StreamConfig {
+    fn default() -> Self {
+        Self {
+            buffer_size: 1024,
+            backpressure: true,
+            timeout: Some(Duration::from_secs(60)),
+        }
+    }
+}
+
+/// Network identity (DID)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkId(String);
+
+impl NetworkId {
+    /// Create a new network ID
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(format!("did:maia:{}", name.into()))
+    }
+
+    /// Parse a DID string
+    pub fn parse(did: impl Into<String>) -> Option<Self> {
+        let did = did.into();
+        if did.starts_with("did:maia:") {
+            Some(Self(did))
+        } else {
+            None
+        }
+    }
+
+    /// Get the network name from DID
+    pub fn name(&self) -> &str {
+        self.0.strip_prefix("did:maia:").unwrap(&self.0)
+    }
+}
+
+impl std::fmt::Display for NetworkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Node identifier within a network
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NodeId {
+    pub network: NetworkId,
+    pub name: String,
+}
+
+impl NodeId {
+    pub fn new(network: NetworkId, name: impl Into<String>) -> Self {
+        Self {
+            network,
+            name: name.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.network, self.name)
+    }
+}
+
+/// Module identifier
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ModuleId {
+    pub node: NodeId,
+    pub name: String,
+}
+
+impl ModuleId {
+    pub fn new(node: NodeId, name: impl Into<String>) -> Self {
+        Self {
+            node,
+            name: name.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ModuleId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.node, self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_parsing() {
+        let cap = Capability::new("ai.nlp.generate");
+        let (ns, cat, action) = cap.parse().unwrap();
+        assert_eq!(ns, "ai");
+        assert_eq!(cat, "nlp");
+        assert_eq!(action, "generate");
+    }
+
+    #[test]
+    fn test_capability_matching() {
+        let cap = Capability::new("ai.nlp.generate");
+
+        assert!(cap.matches("*"));
+        assert!(cap.matches("a1.*"));
+        assert!(cap.matches("a1.nlp.*"));
+        assert!(cap.matches("a1.nlp.generate"));
+        assert!(!cap.matches("ai.vision.*"));
+        assert!(!cap.matches("storage.*"));
+    }
+
+    #[test]
+    fn test_version_compatibility() {
+        let v1 = Version::new(1, 2, 3);
+        let v2 = Version::new(1, 2, 4);
+        let v3 = Version::new(1, 3, 0);
+        let v4 = Version::new(2, 0, 0);
+
+        assert!(v2.is_compatible(&v1)); // Patch version higher
+        assert!(v3.is_compatible(&v1)); // Minor version higher
+        assert!(!v4.is_compatible(&v1)); // Major version different
+        assert!(!v1.is_compatible(&v2)); // Older version
+    }
+
+    #[test]
+    fn test_network_id() {
+        let id = NetworkId::new("test-home");
+        assert_eq!(id.to_string(), "did.maia:test-home");
+        assert_eq!(id.name(), "test-home");
+
+        let parsed = NetworkId::parse("did.maia:test-home").unwrap();
+        assert_eq!(parsed.name(), "test-network");
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.85.0"
 components = ["rustfmt", "clippy", "rust-src"]
-targets = ["wasm32-wasi"]
+# targets = ["wasm32-wasi"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy", "rust-src"]
+targets = ["wasm32-wasi"]


### PR DESCRIPTION
Initial SDK scaffold introducing:
- `maia-sdk` crate with `MaiaModule` trait & lifecycle
- Core types (capability, version, request/response, identities, streaming handles)
- Error model (temporary vs fatal) + contextual error utilities
- Resource & isolation structs, permissions, requirements
- `maia_module!` macro and `prelude` re-exports
- Basic tests and crate docs

Purpose: establish a minimal, reviewable baseline for runtime, routing, and loader work.  
Status: Pre‑alpha (APIs unstable).